### PR TITLE
feat: (WIP) rework test-harness for integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,14 +317,6 @@ jobs:
           if ! cargo make --version 2>/dev/null; then
             cargo install cargo-make --force
           fi
-      # Some integration tests use midenup to compile the example projects
-      - name: Install midenup
-        run: |
-          if ! miden help 2>/dev/null; then
-            cargo install --git https://github.com/0xMiden/midenup
-            midenup init
-          fi
-
       - name: Test
         run: |
           cargo make test -E 'package(midenc-integration-network-tests)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,6 +317,13 @@ jobs:
           if ! cargo make --version 2>/dev/null; then
             cargo install cargo-make --force
           fi
+      # Some integration tests use midenup to compile the example projects
+      - name: Install midenup
+        run: |
+          if ! miden help 2>/dev/null; then
+            cargo install --git https://github.com/0xMiden/midenup
+          fi
+
       - name: Test
         run: |
           cargo make test -E 'package(midenc-integration-network-tests)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,6 +322,7 @@ jobs:
         run: |
           if ! miden help 2>/dev/null; then
             cargo install --git https://github.com/0xMiden/midenup
+            midenup init
           fi
 
       - name: Test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,22 +180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
- "anstyle-parse 0.2.7",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstream"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
-dependencies = [
- "anstyle",
- "anstyle-parse 1.0.0",
+ "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -205,24 +190,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.14"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-parse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -577,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -670,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -680,11 +656,11 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
- "anstream 1.0.0",
+ "anstream",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -693,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -705,15 +681,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.1.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.5"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compact_str"
@@ -1082,9 +1058,9 @@ dependencies = [
 
 [[package]]
 name = "dissimilar"
-version = "1.0.11"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeda16ab4059c5fd2a83f2b9c9e9c981327b18aa8e3b313f7e6563799d4f093e"
+checksum = "8975ffdaa0ef3661bfe02dbdcc06c9f829dfafe6a3c474de366a8d5e44276921"
 
 [[package]]
 name = "dunce"
@@ -1181,7 +1157,7 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
 dependencies = [
- "anstream 0.6.21",
+ "anstream",
  "anstyle",
  "env_filter",
  "jiff",
@@ -1655,7 +1631,7 @@ version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "075e8747af11abcff07d55d98297c9c6c70eb5d6365b25e7b12f02e484935191"
 dependencies = [
- "anstream 0.6.21",
+ "anstream",
  "anstyle",
  "backtrace",
  "serde",
@@ -1825,9 +1801,9 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.12"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
 dependencies = [
  "darling",
  "indoc",
@@ -1886,9 +1862,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.18"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
@@ -2012,9 +1988,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libm"
@@ -2108,16 +2084,18 @@ dependencies = [
 
 [[package]]
 name = "litcheck-core"
-version = "0.4.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00d04c87eac46e722dea009607dbf01109872ccabdaa9088399f2a21c6b2a71d"
+checksum = "e96692d50994f26d57417be79b6719ee179fd8e6b93b3fd2014c1aa60342cc9d"
 dependencies = [
  "Inflector",
+ "anyhow",
  "clap",
  "compact_str 0.9.0",
  "either",
  "glob",
  "hashbrown 0.15.5",
+ "lock_api",
  "log",
  "memchr",
  "miette",
@@ -2134,26 +2112,28 @@ dependencies = [
 
 [[package]]
 name = "litcheck-filecheck"
-version = "0.4.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3068bd232903a957c3dd219019857542dcc8e57eee9db2cebd08c916d8d989c"
+checksum = "51f8835f8046b2cfe2da332500562112991828f00716328a993e728beab8e0ad"
 dependencies = [
  "aho-corasick",
+ "anyhow",
  "bitflags",
  "bstr",
  "clap",
  "either",
  "im-rc",
- "itertools 0.14.0",
  "lalrpop",
  "lalrpop-util",
  "litcheck-core",
  "log",
  "logos 0.16.1",
  "memchr",
+ "miette",
  "regex",
  "regex-automata",
  "regex-syntax",
+ "rustc-hash",
  "smallvec",
  "thiserror",
 ]
@@ -2845,7 +2825,7 @@ dependencies = [
  "semver 1.0.27",
  "serde",
  "thiserror",
- "toml 1.0.7+spec-1.1.0",
+ "toml 1.0.4+spec-1.1.0",
  "walkdir",
 ]
 
@@ -3415,7 +3395,7 @@ dependencies = [
 name = "midenc-log"
 version = "0.7.1"
 dependencies = [
- "anstream 0.6.21",
+ "anstream",
  "anstyle",
  "jiff",
  "log",
@@ -3694,9 +3674,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.4"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -4458,9 +4438,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
 dependencies = [
  "portable-atomic",
 ]
@@ -5391,7 +5371,7 @@ version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c1abc378119f77310836665f8523018532cf7e3faeb3b10b01da5a7321bf8e1"
 dependencies = [
- "anstream 0.6.21",
+ "anstream",
  "anstyle",
  "normalize-line-endings",
  "similar",
@@ -5404,7 +5384,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b750c344002d7cc69afb9da00ebd9b5c0f8ac2eb7d115d9d45d5b5f47718d74"
 dependencies = [
- "anstream 0.6.21",
+ "anstream",
 ]
 
 [[package]]
@@ -5626,9 +5606,9 @@ checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
 
 [[package]]
 name = "tempfile"
-version = "3.27.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",
@@ -5841,22 +5821,22 @@ dependencies = [
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.15",
+ "winnow",
 ]
 
 [[package]]
 name = "toml"
-version = "1.0.7+spec-1.1.0"
+version = "1.0.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd28d57d8a6f6e458bc0b8784f8fdcc4b99a437936056fa122cb234f18656a96"
+checksum = "c94c3321114413476740df133f0d8862c61d87c8d26f04c6841e033c8c80db47"
 dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned 1.0.4",
- "toml_datetime 1.0.1+spec-1.1.0",
+ "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.0",
+ "winnow",
 ]
 
 [[package]]
@@ -5879,9 +5859,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.1+spec-1.1.0"
+version = "1.0.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
 dependencies = [
  "serde_core",
 ]
@@ -5897,7 +5877,7 @@ dependencies = [
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow 0.7.15",
+ "winnow",
 ]
 
 [[package]]
@@ -5912,16 +5892,16 @@ dependencies = [
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.15",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.10+spec-1.1.0"
+version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
- "winnow 1.0.0",
+ "winnow",
 ]
 
 [[package]]
@@ -5932,9 +5912,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.0.7+spec-1.1.0"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"
@@ -6119,9 +6099,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.23"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -6164,7 +6144,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 1.0.7+spec-1.1.0",
+ "toml 1.0.4+spec-1.1.0",
 ]
 
 [[package]]
@@ -6927,12 +6907,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winnow"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
-
-[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7144,18 +7118,18 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2432,6 +2432,7 @@ dependencies = [
  "miden-protocol",
  "miden-remote-prover-client",
  "miden-standards",
+ "miden-testing",
  "miden-tx",
  "miette",
  "prost",
@@ -2447,6 +2448,7 @@ dependencies = [
  "tonic-prost-build",
  "tonic-web-wasm-client",
  "tracing",
+ "uuid",
  "web-sys",
 ]
 
@@ -6285,6 +6287,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "getrandom 0.4.2",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,8 +174,6 @@ miden-field = { version = "0.22" }
 # miden-standards = { git = "https://github.com/0xMiden/protocol", rev = "a53bbe2209f506df87876c8b9c9a1730214f456b" }
 # miden-tx        = { tag = "v0.14.0-beta.4", git = "https://github.com/0xMiden/miden-base" }
 
-
-
 [profile.dev]
 lto = false
 # Needed for 'inventory' to work

--- a/tests/integration-network/Cargo.toml
+++ b/tests/integration-network/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 
 [dependencies]
 # miden-client = { version = "0.14", features = ["std", "tonic", "testing"] }
-miden-client = { git = "https://github.com/0xMiden/miden-client", branch = "release/v0.14.0-beta" }
+miden-client = { git = "https://github.com/0xMiden/miden-client", branch = "release/v0.14.0-beta", features = ["std", "testing"] }
 miden-core.workspace = true
 miden-protocol = { workspace = true, features = ["std", "testing"] }
 miden-standards = { workspace = true, features = ["std"] }

--- a/tests/integration-network/src/mockchain/basic_wallet.rs
+++ b/tests/integration-network/src/mockchain/basic_wallet.rs
@@ -1,23 +1,26 @@
 //! Basic wallet test module
 
 use miden_client::{
-    asset::FungibleAsset, crypto::RandomCoin, note::NoteAssets, transaction::RawOutputNote,
+    account::{
+        AccountComponent, AccountId,
+        component::{BasicWallet, InitStorageData},
+    },
+    asset::{Asset, FungibleAsset},
+    transaction::RawOutputNote,
 };
 use miden_core::Felt;
-use miden_protocol::account::{auth::AuthScheme, AccountId};
-use miden_testing::{AccountState, Auth, MockChain};
+use miden_protocol::{account::auth::AuthScheme, crypto::rand::RandomCoin};
+use miden_standards::testing::note::NoteBuilder;
+use miden_testing::{Auth, MockChain};
 use midenc_expect_test::expect;
 
 use super::{
     cycle_helpers::{note_cycles, prologue_cycles, tx_script_processing_cycles},
     helpers::{
-        assert_account_has_fungible_asset, build_asset_transfer_tx,
-        build_existing_basic_wallet_account_builder, build_send_notes_script, compile_rust_package,
-        create_note_from_package, execute_tx, to_core_felts, NoteCreationConfig,
+        assert_account_has_fungible_asset, build_asset_transfer_tx, build_send_notes_script,
+        compile_rust_package, execute_tx, to_core_felts,
     },
 };
-use crate::mockchain::helpers::compile_rust_package;
-
 /// Converts the P2IDE note payload into protocol storage order for the basic-wallet tests.
 fn to_p2ide_storage_felts(
     target: &AccountId,
@@ -65,7 +68,7 @@ pub fn test_basic_wallet_p2id() {
     let bob_account = builder
         .add_existing_account_from_components(
             Auth::BasicAuth {
-                auth_sceme: AuthScheme::Falcon512Poseidon2,
+                auth_scheme: AuthScheme::Falcon512Poseidon2,
             },
             [wallet_component],
         )
@@ -80,11 +83,11 @@ pub fn test_basic_wallet_p2id() {
     let mint_amount = 100_000u64; // 100,000 tokens
     let mint_asset = FungibleAsset::new(faucet_id, mint_amount).unwrap();
 
-    let mut note_rng = RpoRandomCoin::new(note_package.unwrap_program().hash());
+    let mut note_rng = RandomCoin::new(note_package.unwrap_program().hash());
     let p2id_note_mint = NoteBuilder::new(faucet_id, &mut note_rng)
         .package((*note_package).clone())
         .add_assets([Asset::from(mint_asset)])
-        .note_inputs(to_core_felts(&alice_id))
+        .note_storage(to_core_felts(&alice_id))
         .unwrap()
         .build()
         .unwrap();
@@ -173,7 +176,7 @@ pub fn test_basic_wallet_p2ide() {
     let alice_account = builder
         .add_existing_account_from_components(
             Auth::BasicAuth {
-                auth_sceme: AuthScheme::Falcon512Poseidon2,
+                auth_scheme: AuthScheme::Falcon512Poseidon2,
             },
             [wallet_component.clone(), BasicWallet.into()],
         )
@@ -183,7 +186,7 @@ pub fn test_basic_wallet_p2ide() {
     let bob_account = builder
         .add_existing_account_from_components(
             Auth::BasicAuth {
-                auth_sceme: AuthScheme::Falcon512Poseidon2,
+                auth_scheme: AuthScheme::Falcon512Poseidon2,
             },
             [wallet_component],
         )
@@ -198,11 +201,11 @@ pub fn test_basic_wallet_p2ide() {
     let mint_amount = 100_000u64;
     let mint_asset = FungibleAsset::new(faucet_id, mint_amount).unwrap();
 
-    let p2id_rng = RpoRandomCoin::new(p2id_note_package.unwrap_program().hash());
+    let p2id_rng = RandomCoin::new(p2id_note_package.unwrap_program().hash());
     let p2id_note_mint = NoteBuilder::new(faucet_id, p2id_rng)
         .package((*p2id_note_package).clone())
         .add_assets([Asset::from(mint_asset)])
-        .note_inputs(to_core_felts(&alice_id))
+        .note_storage(to_core_felts(&alice_id))
         .unwrap()
         .build()
         .unwrap();
@@ -231,15 +234,11 @@ pub fn test_basic_wallet_p2ide() {
     let timelock_height = Felt::new(0);
     let reclaim_height = Felt::new(0);
 
-    let p2ide_rng = RpoRandomCoin::new(p2ide_note_package.unwrap_program().hash());
+    let p2ide_rng = RandomCoin::new(p2ide_note_package.unwrap_program().hash());
     let p2ide_note = NoteBuilder::new(alice_id, p2ide_rng)
         .package((*p2ide_note_package).clone())
         .add_assets([Asset::from(transfer_asset)])
-        .note_inputs({
-            let mut inputs = to_core_felts(&bob_id);
-            inputs.extend([timelock_height, reclaim_height]);
-            inputs
-        })
+        .note_storage(to_p2ide_storage_felts(&bob_id, reclaim_height, timelock_height))
         .unwrap()
         .build()
         .unwrap();
@@ -302,7 +301,7 @@ pub fn test_basic_wallet_p2ide_reclaim() {
     let alice_account = builder
         .add_existing_account_from_components(
             Auth::BasicAuth {
-                auth_sceme: AuthScheme::Falcon512Poseidon2,
+                auth_scheme: AuthScheme::Falcon512Poseidon2,
             },
             [wallet_component.clone(), BasicWallet.into()],
         )
@@ -312,7 +311,7 @@ pub fn test_basic_wallet_p2ide_reclaim() {
     let bob_account = builder
         .add_existing_account_from_components(
             Auth::BasicAuth {
-                auth_sceme: AuthScheme::Falcon512Poseidon2,
+                auth_scheme: AuthScheme::Falcon512Poseidon2,
             },
             [wallet_component],
         )
@@ -327,11 +326,11 @@ pub fn test_basic_wallet_p2ide_reclaim() {
     let mint_amount = 100_000u64;
     let mint_asset = FungibleAsset::new(faucet_id, mint_amount).unwrap();
 
-    let p2id_rng = RpoRandomCoin::new(p2id_note_package.unwrap_program().hash());
+    let p2id_rng = RandomCoin::new(p2id_note_package.unwrap_program().hash());
     let p2id_note_mint = NoteBuilder::new(faucet_id, p2id_rng)
         .package((*p2id_note_package).clone())
         .add_assets([Asset::from(mint_asset)])
-        .note_inputs(to_core_felts(&alice_id))
+        .note_storage(to_core_felts(&alice_id))
         .unwrap()
         .build()
         .unwrap();
@@ -360,15 +359,11 @@ pub fn test_basic_wallet_p2ide_reclaim() {
     let timelock_height = Felt::new(0);
     let reclaim_height = Felt::new(1);
 
-    let p2ide_rng = RpoRandomCoin::new(p2ide_note_package.unwrap_program().hash());
+    let p2ide_rng = RandomCoin::new(p2ide_note_package.unwrap_program().hash());
     let p2ide_note = NoteBuilder::new(alice_id, p2ide_rng)
         .package((*p2ide_note_package).clone())
         .add_assets([Asset::from(transfer_asset)])
-        .note_inputs({
-            let mut inputs = to_core_felts(&bob_id);
-            inputs.extend([timelock_height, reclaim_height]);
-            inputs
-        })
+        .note_storage(to_p2ide_storage_felts(&bob_id, reclaim_height, timelock_height))
         .unwrap()
         .build()
         .unwrap();

--- a/tests/integration-network/src/mockchain/basic_wallet.rs
+++ b/tests/integration-network/src/mockchain/basic_wallet.rs
@@ -4,18 +4,19 @@ use miden_client::{
     asset::FungibleAsset, crypto::RandomCoin, note::NoteAssets, transaction::RawOutputNote,
 };
 use miden_core::Felt;
-use miden_protocol::account::{AccountId, auth::AuthScheme};
+use miden_protocol::account::{auth::AuthScheme, AccountId};
 use miden_testing::{AccountState, Auth, MockChain};
 use midenc_expect_test::expect;
 
 use super::{
     cycle_helpers::{note_cycles, prologue_cycles, tx_script_processing_cycles},
     helpers::{
-        NoteCreationConfig, assert_account_has_fungible_asset, build_asset_transfer_tx,
+        assert_account_has_fungible_asset, build_asset_transfer_tx,
         build_existing_basic_wallet_account_builder, build_send_notes_script, compile_rust_package,
-        create_note_from_package, execute_tx, to_core_felts,
+        create_note_from_package, execute_tx, to_core_felts, NoteCreationConfig,
     },
 };
+use crate::mockchain::helpers::compile_rust_package;
 
 /// Converts the P2IDE note payload into protocol storage order for the basic-wallet tests.
 fn to_p2ide_storage_felts(
@@ -34,6 +35,9 @@ pub fn test_basic_wallet_p2id() {
     let note_package = compile_rust_package("../../examples/p2id-note", true);
     let tx_script_package = compile_rust_package("../../examples/basic-wallet-tx-script", true);
 
+    let wallet_component =
+        AccountComponent::from_package(&wallet_package, &InitStorageData::default()).unwrap();
+
     let mut builder = MockChain::builder();
     let max_supply = 1_000_000_000u64;
     let faucet_account = builder
@@ -49,23 +53,21 @@ pub fn test_basic_wallet_p2id() {
     let faucet_id = faucet_account.id();
 
     let alice_account = builder
-        .add_account_from_builder(
+        .add_existing_account_from_components(
             Auth::BasicAuth {
                 auth_scheme: AuthScheme::Falcon512Poseidon2,
             },
-            build_existing_basic_wallet_account_builder(wallet_package.clone(), false, [1_u8; 32]),
-            AccountState::Exists,
+            [wallet_component.clone()],
         )
         .unwrap();
     let alice_id = alice_account.id();
 
     let bob_account = builder
-        .add_account_from_builder(
+        .add_existing_account_from_components(
             Auth::BasicAuth {
-                auth_scheme: AuthScheme::Falcon512Poseidon2,
+                auth_sceme: AuthScheme::Falcon512Poseidon2,
             },
-            build_existing_basic_wallet_account_builder(wallet_package, false, [2_u8; 32]),
-            AccountState::Exists,
+            [wallet_component],
         )
         .unwrap();
     let bob_id = bob_account.id();
@@ -78,17 +80,14 @@ pub fn test_basic_wallet_p2id() {
     let mint_amount = 100_000u64; // 100,000 tokens
     let mint_asset = FungibleAsset::new(faucet_id, mint_amount).unwrap();
 
-    let mut note_rng = RandomCoin::new(note_package.unwrap_program().hash());
-    let p2id_note_mint = create_note_from_package(
-        note_package.clone(),
-        faucet_id,
-        NoteCreationConfig {
-            assets: NoteAssets::new(vec![mint_asset.into()]).unwrap(),
-            inputs: to_core_felts(&alice_id),
-            ..Default::default()
-        },
-        &mut note_rng,
-    );
+    let mut note_rng = RpoRandomCoin::new(note_package.unwrap_program().hash());
+    let p2id_note_mint = NoteBuilder::new(faucet_id, &mut note_rng)
+        .package((*note_package).clone())
+        .add_assets([Asset::from(mint_asset)])
+        .note_inputs(to_core_felts(&alice_id))
+        .unwrap()
+        .build()
+        .unwrap();
 
     let faucet_account = chain.committed_account(faucet_id).unwrap().clone();
     let mint_tx_script =
@@ -154,6 +153,9 @@ pub fn test_basic_wallet_p2ide() {
     let p2id_note_package = compile_rust_package("../../examples/p2id-note", true);
     let p2ide_note_package = compile_rust_package("../../examples/p2ide-note", true);
 
+    let wallet_component =
+        AccountComponent::from_package(&wallet_package, &InitStorageData::default()).unwrap();
+
     let mut builder = MockChain::builder();
     let max_supply = 1_000_000_000u64;
     let faucet_account = builder
@@ -169,23 +171,21 @@ pub fn test_basic_wallet_p2ide() {
     let faucet_id = faucet_account.id();
 
     let alice_account = builder
-        .add_account_from_builder(
+        .add_existing_account_from_components(
             Auth::BasicAuth {
-                auth_scheme: AuthScheme::Falcon512Poseidon2,
+                auth_sceme: AuthScheme::Falcon512Poseidon2,
             },
-            build_existing_basic_wallet_account_builder(wallet_package.clone(), true, [3_u8; 32]),
-            AccountState::Exists,
+            [wallet_component.clone(), BasicWallet.into()],
         )
         .unwrap();
     let alice_id = alice_account.id();
 
     let bob_account = builder
-        .add_account_from_builder(
+        .add_existing_account_from_components(
             Auth::BasicAuth {
-                auth_scheme: AuthScheme::Falcon512Poseidon2,
+                auth_sceme: AuthScheme::Falcon512Poseidon2,
             },
-            build_existing_basic_wallet_account_builder(wallet_package, false, [4_u8; 32]),
-            AccountState::Exists,
+            [wallet_component],
         )
         .unwrap();
     let bob_id = bob_account.id();
@@ -198,17 +198,14 @@ pub fn test_basic_wallet_p2ide() {
     let mint_amount = 100_000u64;
     let mint_asset = FungibleAsset::new(faucet_id, mint_amount).unwrap();
 
-    let mut p2id_rng = RandomCoin::new(p2id_note_package.unwrap_program().hash());
-    let p2id_note_mint = create_note_from_package(
-        p2id_note_package.clone(),
-        faucet_id,
-        NoteCreationConfig {
-            assets: NoteAssets::new(vec![mint_asset.into()]).unwrap(),
-            inputs: to_core_felts(&alice_id),
-            ..Default::default()
-        },
-        &mut p2id_rng,
-    );
+    let p2id_rng = RpoRandomCoin::new(p2id_note_package.unwrap_program().hash());
+    let p2id_note_mint = NoteBuilder::new(faucet_id, p2id_rng)
+        .package((*p2id_note_package).clone())
+        .add_assets([Asset::from(mint_asset)])
+        .note_inputs(to_core_felts(&alice_id))
+        .unwrap()
+        .build()
+        .unwrap();
 
     let faucet_account = chain.committed_account(faucet_id).unwrap().clone();
     let mint_tx_script =
@@ -234,17 +231,18 @@ pub fn test_basic_wallet_p2ide() {
     let timelock_height = Felt::new(0);
     let reclaim_height = Felt::new(0);
 
-    let mut p2ide_rng = RandomCoin::new(p2ide_note_package.unwrap_program().hash());
-    let p2ide_note = create_note_from_package(
-        p2ide_note_package,
-        alice_id,
-        NoteCreationConfig {
-            assets: NoteAssets::new(vec![transfer_asset.into()]).unwrap(),
-            inputs: to_p2ide_storage_felts(&bob_id, reclaim_height, timelock_height),
-            ..Default::default()
-        },
-        &mut p2ide_rng,
-    );
+    let p2ide_rng = RpoRandomCoin::new(p2ide_note_package.unwrap_program().hash());
+    let p2ide_note = NoteBuilder::new(alice_id, p2ide_rng)
+        .package((*p2ide_note_package).clone())
+        .add_assets([Asset::from(transfer_asset)])
+        .note_inputs({
+            let mut inputs = to_core_felts(&bob_id);
+            inputs.extend([timelock_height, reclaim_height]);
+            inputs
+        })
+        .unwrap()
+        .build()
+        .unwrap();
 
     let alice_account = chain.committed_account(alice_id).unwrap().clone();
     let transfer_tx_script =
@@ -298,24 +296,25 @@ pub fn test_basic_wallet_p2ide_reclaim() {
         .unwrap();
     let faucet_id = faucet_account.id();
 
+    let wallet_component =
+        AccountComponent::from_package(&wallet_package, &InitStorageData::default()).unwrap();
+
     let alice_account = builder
-        .add_account_from_builder(
+        .add_existing_account_from_components(
             Auth::BasicAuth {
-                auth_scheme: AuthScheme::Falcon512Poseidon2,
+                auth_sceme: AuthScheme::Falcon512Poseidon2,
             },
-            build_existing_basic_wallet_account_builder(wallet_package.clone(), true, [5_u8; 32]),
-            AccountState::Exists,
+            [wallet_component.clone(), BasicWallet.into()],
         )
         .unwrap();
     let alice_id = alice_account.id();
 
     let bob_account = builder
-        .add_account_from_builder(
+        .add_existing_account_from_components(
             Auth::BasicAuth {
-                auth_scheme: AuthScheme::Falcon512Poseidon2,
+                auth_sceme: AuthScheme::Falcon512Poseidon2,
             },
-            build_existing_basic_wallet_account_builder(wallet_package, false, [6_u8; 32]),
-            AccountState::Exists,
+            [wallet_component],
         )
         .unwrap();
     let bob_id = bob_account.id();
@@ -328,17 +327,14 @@ pub fn test_basic_wallet_p2ide_reclaim() {
     let mint_amount = 100_000u64;
     let mint_asset = FungibleAsset::new(faucet_id, mint_amount).unwrap();
 
-    let mut p2id_rng = RandomCoin::new(p2id_note_package.unwrap_program().hash());
-    let p2id_note_mint = create_note_from_package(
-        p2id_note_package.clone(),
-        faucet_id,
-        NoteCreationConfig {
-            assets: NoteAssets::new(vec![mint_asset.into()]).unwrap(),
-            inputs: to_core_felts(&alice_id),
-            ..Default::default()
-        },
-        &mut p2id_rng,
-    );
+    let p2id_rng = RpoRandomCoin::new(p2id_note_package.unwrap_program().hash());
+    let p2id_note_mint = NoteBuilder::new(faucet_id, p2id_rng)
+        .package((*p2id_note_package).clone())
+        .add_assets([Asset::from(mint_asset)])
+        .note_inputs(to_core_felts(&alice_id))
+        .unwrap()
+        .build()
+        .unwrap();
 
     let faucet_account = chain.committed_account(faucet_id).unwrap().clone();
     let mint_tx_script =
@@ -364,17 +360,18 @@ pub fn test_basic_wallet_p2ide_reclaim() {
     let timelock_height = Felt::new(0);
     let reclaim_height = Felt::new(1);
 
-    let mut p2ide_rng = RandomCoin::new(p2ide_note_package.unwrap_program().hash());
-    let p2ide_note = create_note_from_package(
-        p2ide_note_package,
-        alice_id,
-        NoteCreationConfig {
-            assets: NoteAssets::new(vec![transfer_asset.into()]).unwrap(),
-            inputs: to_p2ide_storage_felts(&bob_id, reclaim_height, timelock_height),
-            ..Default::default()
-        },
-        &mut p2ide_rng,
-    );
+    let p2ide_rng = RpoRandomCoin::new(p2ide_note_package.unwrap_program().hash());
+    let p2ide_note = NoteBuilder::new(alice_id, p2ide_rng)
+        .package((*p2ide_note_package).clone())
+        .add_assets([Asset::from(transfer_asset)])
+        .note_inputs({
+            let mut inputs = to_core_felts(&bob_id);
+            inputs.extend([timelock_height, reclaim_height]);
+            inputs
+        })
+        .unwrap()
+        .build()
+        .unwrap();
 
     let alice_account = chain.committed_account(alice_id).unwrap().clone();
     let transfer_tx_script =

--- a/tests/integration-network/src/mockchain/counter_contract.rs
+++ b/tests/integration-network/src/mockchain/counter_contract.rs
@@ -1,13 +1,16 @@
 //! Counter contract test module
 
 use miden_client::{
-    Word, account::component::BasicWallet, crypto::RandomCoin, note::NoteTag,
+    account::component::BasicWallet,
+    crypto::{RandomCoin, RpoRandomCoin},
+    note::NoteTag,
     transaction::RawOutputNote,
+    Word,
 };
 use miden_core::Felt;
 use miden_protocol::account::{
-    AccountBuilder, AccountStorageMode, AccountType, StorageMap, StorageMapKey, StorageSlot,
-    auth::AuthScheme,
+    auth::AuthScheme, AccountBuilder, AccountStorageMode, AccountType, StorageMap, StorageMapKey,
+    StorageSlot, StorageSlotName,
 };
 use miden_testing::{AccountState, Auth, MockChain};
 use midenc_expect_test::expect;
@@ -15,8 +18,8 @@ use midenc_expect_test::expect;
 use super::{
     cycle_helpers::note_cycles,
     helpers::{
-        NoteCreationConfig, account_component_from_package, assert_counter_storage,
-        compile_rust_package, counter_storage_slot_name, create_note_from_package, execute_tx,
+        account_component_from_package, assert_counter_storage, compile_rust_package,
+        counter_storage_slot_name, create_note_from_package, execute_tx, NoteCreationConfig,
     },
 };
 use crate::mockchain::helpers::COUNTER_CONTRACT_STORAGE_KEY;
@@ -36,35 +39,27 @@ pub fn test_counter_contract() {
             .unwrap(),
     )];
 
-    let counter_component = account_component_from_package(contract_package, storage_slots);
-    let counter_account_builder = AccountBuilder::new([0_u8; 32])
-        .account_type(AccountType::RegularAccountUpdatableCode)
-        .storage_mode(AccountStorageMode::Public)
-        .with_component(BasicWallet)
-        .with_component(counter_component);
+    let mut init_storage_data = InitStorageData::default();
+    init_storage_data
+        .insert_map_entry(counter_storage_slot.clone(), key, value)
+        .unwrap();
+    let contract_package = AccountComponent::from_package(&contract_package, &init_storage_data)
+        .expect("Failed to build account component from counter project");
 
     let mut builder = MockChain::builder();
     let counter_account = builder
-        .add_account_from_builder(
-            Auth::BasicAuth {
-                auth_scheme: AuthScheme::Falcon512Poseidon2,
-            },
-            counter_account_builder,
-            AccountState::Exists,
+        .add_existing_account_from_components(
+            Auth::BasicAuth,
+            [BasicWallet.into(), contract_package],
         )
-        .expect("failed to add counter account to mock chain builder");
+        .unwrap();
 
-    let mut rng = RandomCoin::new(note_package.clone().unwrap_program().hash());
-    let counter_note = create_note_from_package(
-        note_package,
-        counter_account.id(),
-        NoteCreationConfig {
-            tag: NoteTag::with_account_target(counter_account.id()),
-            ..Default::default()
-        },
-        &mut rng,
-    );
-    builder.add_output_note(RawOutputNote::Full(counter_note.clone()));
+    let mut rng = RpoRandomCoin::new(note_package.clone().unwrap_program().hash());
+    let counter_note = NoteBuilder::new(counter_account.id(), &mut rng)
+        .package((*note_package).clone())
+        .build()
+        .unwrap();
+    builder.add_output_note(OutputNote::Full(counter_note.clone()));
 
     let mut chain = builder.build().expect("failed to build mock chain");
     chain.prove_next_block().unwrap();

--- a/tests/integration-network/src/mockchain/counter_contract.rs
+++ b/tests/integration-network/src/mockchain/counter_contract.rs
@@ -1,28 +1,23 @@
 //! Counter contract test module
 
 use miden_client::{
-    account::component::BasicWallet,
-    crypto::{RandomCoin, RpoRandomCoin},
-    note::NoteTag,
-    transaction::RawOutputNote,
     Word,
+    account::{AccountComponent, component::InitStorageData},
+    transaction::RawOutputNote,
 };
 use miden_core::Felt;
-use miden_protocol::account::{
-    auth::AuthScheme, AccountBuilder, AccountStorageMode, AccountType, StorageMap, StorageMapKey,
-    StorageSlot, StorageSlotName,
-};
-use miden_testing::{AccountState, Auth, MockChain};
+use miden_protocol::{account::auth::AuthScheme, crypto::rand::RandomCoin};
+use miden_standards::testing::note::NoteBuilder;
+use miden_testing::{Auth, MockChain};
 use midenc_expect_test::expect;
 
 use super::{
     cycle_helpers::note_cycles,
     helpers::{
-        account_component_from_package, assert_counter_storage, compile_rust_package,
-        counter_storage_slot_name, create_note_from_package, execute_tx, NoteCreationConfig,
+        COUNTER_CONTRACT_STORAGE_KEY, assert_counter_storage, compile_rust_package,
+        counter_storage_slot_name, execute_tx,
     },
 };
-use crate::mockchain::helpers::COUNTER_CONTRACT_STORAGE_KEY;
 
 /// Tests the counter contract deployment and note consumption workflow on a mock chain.
 #[test]
@@ -33,33 +28,30 @@ pub fn test_counter_contract() {
 
     let value = Word::from([Felt::ZERO, Felt::ZERO, Felt::ZERO, Felt::ONE]);
     let counter_storage_slot = counter_storage_slot_name();
-    let storage_slots = vec![StorageSlot::with_map(
-        counter_storage_slot.clone(),
-        StorageMap::with_entries([(StorageMapKey::new(COUNTER_CONTRACT_STORAGE_KEY), value)])
-            .unwrap(),
-    )];
 
     let mut init_storage_data = InitStorageData::default();
     init_storage_data
-        .insert_map_entry(counter_storage_slot.clone(), key, value)
+        .insert_map_entry(counter_storage_slot.clone(), COUNTER_CONTRACT_STORAGE_KEY, value)
         .unwrap();
-    let contract_package = AccountComponent::from_package(&contract_package, &init_storage_data)
+    let contract_component = AccountComponent::from_package(&contract_package, &init_storage_data)
         .expect("Failed to build account component from counter project");
 
     let mut builder = MockChain::builder();
     let counter_account = builder
         .add_existing_account_from_components(
-            Auth::BasicAuth,
-            [BasicWallet.into(), contract_package],
+            Auth::BasicAuth {
+                auth_scheme: AuthScheme::Falcon512Poseidon2,
+            },
+            [contract_component],
         )
         .unwrap();
 
-    let mut rng = RpoRandomCoin::new(note_package.clone().unwrap_program().hash());
+    let mut rng = RandomCoin::new(note_package.clone().unwrap_program().hash());
     let counter_note = NoteBuilder::new(counter_account.id(), &mut rng)
         .package((*note_package).clone())
         .build()
         .unwrap();
-    builder.add_output_note(OutputNote::Full(counter_note.clone()));
+    builder.add_output_note(RawOutputNote::Full(counter_note.clone()));
 
     let mut chain = builder.build().expect("failed to build mock chain");
     chain.prove_next_block().unwrap();

--- a/tests/integration-network/src/mockchain/counter_contract_no_auth.rs
+++ b/tests/integration-network/src/mockchain/counter_contract_no_auth.rs
@@ -1,26 +1,31 @@
 //! Counter contract test with no-auth authentication component
 
 use miden_client::{
-    Word, account::component::BasicWallet, crypto::RandomCoin, note::NoteTag,
-    transaction::RawOutputNote,
+    account::component::BasicWallet, crypto::RandomCoin, note::NoteTag, transaction::RawOutputNote,
+    Word,
 };
-use miden_core::Felt;
+use miden_core::{Felt, FieldElement};
 use miden_protocol::account::{
-    AccountBuilder, AccountStorageMode, AccountType, StorageMap, StorageMapKey, StorageSlot,
-    auth::AuthScheme,
+    auth::AuthScheme, AccountBuilder, AccountStorageMode, AccountType, StorageMap, StorageMapKey,
+    StorageSlot, StorageSlotName,
 };
 use miden_testing::{AccountState, Auth, MockChain};
 use midenc_expect_test::expect;
 
 use super::{
+    crypto::RpoRandomCoin,
     cycle_helpers::{auth_procedure_cycles, note_cycles},
     helpers::{
-        NoteCreationConfig, assert_counter_storage,
-        build_existing_counter_account_builder_with_auth_package, compile_rust_package,
-        counter_storage_slot_name, create_note_from_package, execute_tx,
+        assert_counter_storage, build_existing_counter_account_builder_with_auth_package,
+        compile_rust_package, counter_storage_slot_name, create_note_from_package, execute_tx,
+        NoteCreationConfig,
     },
+    note::NoteTag,
+    testing::{AccountState, Auth, MockChain, NoteBuilder},
+    transaction::OutputNote,
+    Word,
 };
-use crate::mockchain::helpers::COUNTER_CONTRACT_STORAGE_KEY;
+use crate::mockchain::helpers::compile_rust_package;
 
 /// Tests the counter contract with a "no-auth" authentication component.
 ///
@@ -32,7 +37,7 @@ use crate::mockchain::helpers::COUNTER_CONTRACT_STORAGE_KEY;
 #[test]
 pub fn test_counter_contract_no_auth() {
     // Compile the contracts first (before creating any runtime)
-    let contract_package = compile_rust_package("../../examples/counter-contract", true);
+    let counter_package = compile_rust_package("../../examples/counter-contract", true);
     let note_package = compile_rust_package("../../examples/counter-note", true);
     let no_auth_auth_component =
         compile_rust_package("../../examples/auth-component-no-auth", true);
@@ -46,12 +51,23 @@ pub fn test_counter_contract_no_auth() {
     )];
 
     let mut builder = MockChain::builder();
+    let counter_component = {
+        let mut init_storage_data = InitStorageData::default();
+        init_storage_data
+            .insert_map_entry(counter_storage_slot.clone(), key, value)
+            .unwrap();
+        AccountComponent::from_package(&counter_package, &init_storage_data).unwrap()
+    };
+
+    let mut counter_init_storage_data = InitStorageData::default();
+    counter_init_storage_data
+        .insert_map_entry(counter_storage_slot.clone(), key, value)
+        .expect("failed to insert counter map entry");
 
     let counter_account = build_existing_counter_account_builder_with_auth_package(
-        contract_package,
+        counter_component,
         no_auth_auth_component,
         vec![],
-        counter_storage_slots,
         [0_u8; 32],
     )
     .build_existing()
@@ -79,16 +95,13 @@ pub fn test_counter_contract_no_auth() {
     eprintln!("Sender account ID: {:?}", sender_account.id().to_hex());
 
     // Sender creates the counter note (note script increments counter's storage on consumption)
-    let mut rng = RandomCoin::new(note_package.unwrap_program().hash());
-    let counter_note = create_note_from_package(
-        note_package.clone(),
-        sender_account.id(),
-        NoteCreationConfig {
-            tag: NoteTag::with_account_target(counter_account.id()),
-            ..Default::default()
-        },
-        &mut rng,
-    );
+    let rng = RpoRandomCoin::new(note_package.unwrap_program().hash());
+    let counter_note = NoteBuilder::new(sender_account.id(), rng)
+        .package((*note_package).clone())
+        .tag(NoteTag::with_account_target(counter_account.id()).into())
+        .build()
+        .unwrap();
+
     eprintln!("Counter note hash: {:?}", counter_note.id().to_hex());
     builder.add_output_note(RawOutputNote::Full(counter_note.clone()));
 

--- a/tests/integration-network/src/mockchain/counter_contract_no_auth.rs
+++ b/tests/integration-network/src/mockchain/counter_contract_no_auth.rs
@@ -1,31 +1,28 @@
 //! Counter contract test with no-auth authentication component
 
 use miden_client::{
-    account::component::BasicWallet, crypto::RandomCoin, note::NoteTag, transaction::RawOutputNote,
     Word,
+    account::{AccountComponent, component::InitStorageData},
+    note::NoteTag,
+    transaction::RawOutputNote,
 };
-use miden_core::{Felt, FieldElement};
-use miden_protocol::account::{
-    auth::AuthScheme, AccountBuilder, AccountStorageMode, AccountType, StorageMap, StorageMapKey,
-    StorageSlot, StorageSlotName,
+use miden_core::Felt;
+use miden_protocol::{
+    account::{AccountBuilder, AccountStorageMode, AccountType, auth::AuthScheme},
+    crypto::rand::RandomCoin,
 };
+use miden_standards::testing::note::NoteBuilder;
 use miden_testing::{AccountState, Auth, MockChain};
 use midenc_expect_test::expect;
 
 use super::{
-    crypto::RpoRandomCoin,
     cycle_helpers::{auth_procedure_cycles, note_cycles},
     helpers::{
-        assert_counter_storage, build_existing_counter_account_builder_with_auth_package,
-        compile_rust_package, counter_storage_slot_name, create_note_from_package, execute_tx,
-        NoteCreationConfig,
+        COUNTER_CONTRACT_STORAGE_KEY, assert_counter_storage,
+        build_existing_counter_account_builder_with_auth_package, compile_rust_package,
+        counter_storage_slot_name, execute_tx,
     },
-    note::NoteTag,
-    testing::{AccountState, Auth, MockChain, NoteBuilder},
-    transaction::OutputNote,
-    Word,
 };
-use crate::mockchain::helpers::compile_rust_package;
 
 /// Tests the counter contract with a "no-auth" authentication component.
 ///
@@ -44,26 +41,16 @@ pub fn test_counter_contract_no_auth() {
 
     let value = Word::from([Felt::ZERO, Felt::ZERO, Felt::ZERO, Felt::ONE]);
     let counter_storage_slot = counter_storage_slot_name();
-    let counter_storage_slots = vec![StorageSlot::with_map(
-        counter_storage_slot.clone(),
-        StorageMap::with_entries([(StorageMapKey::new(COUNTER_CONTRACT_STORAGE_KEY), value)])
-            .unwrap(),
-    )];
 
-    let mut builder = MockChain::builder();
     let counter_component = {
         let mut init_storage_data = InitStorageData::default();
         init_storage_data
-            .insert_map_entry(counter_storage_slot.clone(), key, value)
+            .insert_map_entry(counter_storage_slot.clone(), COUNTER_CONTRACT_STORAGE_KEY, value)
             .unwrap();
         AccountComponent::from_package(&counter_package, &init_storage_data).unwrap()
     };
 
-    let mut counter_init_storage_data = InitStorageData::default();
-    counter_init_storage_data
-        .insert_map_entry(counter_storage_slot.clone(), key, value)
-        .expect("failed to insert counter map entry");
-
+    let mut builder = MockChain::builder();
     let counter_account = build_existing_counter_account_builder_with_auth_package(
         counter_component,
         no_auth_auth_component,
@@ -82,7 +69,7 @@ pub fn test_counter_contract_no_auth() {
     let sender_builder = AccountBuilder::new(seed)
         .account_type(AccountType::RegularAccountUpdatableCode)
         .storage_mode(AccountStorageMode::Public)
-        .with_component(BasicWallet);
+        .with_component(miden_client::account::component::BasicWallet);
     let sender_account = builder
         .add_account_from_builder(
             Auth::BasicAuth {
@@ -95,7 +82,7 @@ pub fn test_counter_contract_no_auth() {
     eprintln!("Sender account ID: {:?}", sender_account.id().to_hex());
 
     // Sender creates the counter note (note script increments counter's storage on consumption)
-    let rng = RpoRandomCoin::new(note_package.unwrap_program().hash());
+    let rng = RandomCoin::new(note_package.unwrap_program().hash());
     let counter_note = NoteBuilder::new(sender_account.id(), rng)
         .package((*note_package).clone())
         .tag(NoteTag::with_account_target(counter_account.id()).into())

--- a/tests/integration-network/src/mockchain/counter_contract_rust_auth.rs
+++ b/tests/integration-network/src/mockchain/counter_contract_rust_auth.rs
@@ -5,7 +5,11 @@
 //! contract account that uses the Rust-compiled auth component.
 
 use miden_client::{
-    auth::BasicAuthenticator, crypto::RandomCoin, note::NoteTag, transaction::RawOutputNote,
+    auth::BasicAuthenticator,
+    crypto::RpoRandomCoin,
+    note::NoteTag,
+    testing::{MockChain, NoteBuilder},
+    transaction::{OutputNote, RawOutputNote},
 };
 use miden_testing::MockChain;
 use midenc_expect_test::expect;
@@ -13,11 +17,12 @@ use midenc_expect_test::expect;
 use super::{
     cycle_helpers::auth_procedure_cycles,
     helpers::{
-        NoteCreationConfig, assert_counter_storage, block_on,
-        build_counter_account_with_rust_rpo_auth, build_send_notes_script, compile_rust_package,
-        counter_storage_slot_name, create_note_from_package,
+        assert_counter_storage, block_on, build_counter_account_with_rust_rpo_auth,
+        build_send_notes_script, compile_rust_package, counter_storage_slot_name,
+        create_note_from_package, NoteCreationConfig,
     },
 };
+use crate::mockchain::helpers::compile_rust_package;
 
 /// Verify that another client (without the RPO-Falcon512 key) cannot create notes for
 /// the counter account which uses the Rust-compiled RPO-Falcon512 authentication component.
@@ -55,16 +60,12 @@ pub fn test_counter_contract_rust_auth_blocks_unauthorized_note_creation() {
     );
 
     // Positive check: original client (with the key) can create a note
-    let mut rng = RandomCoin::new(note_package.unwrap_program().hash());
-    let own_note = create_note_from_package(
-        note_package.clone(),
-        counter_account.id(),
-        NoteCreationConfig {
-            tag: NoteTag::with_account_target(counter_account.id()),
-            ..Default::default()
-        },
-        &mut rng,
-    );
+    let rng = RpoRandomCoin::new(note_package.unwrap_program().hash());
+    let own_note = NoteBuilder::new(counter_account.id(), rng)
+        .package((*note_package).clone())
+        .tag(NoteTag::with_account_target(counter_account.id()).into())
+        .build()
+        .expect("failed to build own_note");
     let tx_script = build_send_notes_script(&counter_account, std::slice::from_ref(&own_note));
     let authenticator = BasicAuthenticator::new(std::slice::from_ref(&secret_key));
 
@@ -86,15 +87,12 @@ pub fn test_counter_contract_rust_auth_blocks_unauthorized_note_creation() {
 
     // Negative check: without the RPO-Falcon512 key, creating output notes should fail.
     let counter_account = chain.committed_account(counter_account_id).unwrap().clone();
-    let forged_note = create_note_from_package(
-        note_package,
-        counter_account.id(),
-        NoteCreationConfig {
-            tag: NoteTag::with_account_target(counter_account.id()),
-            ..Default::default()
-        },
-        &mut rng,
-    );
+    let rng = RpoRandomCoin::new(note_package.unwrap_program().hash());
+    let forged_note = NoteBuilder::new(counter_account.id(), rng)
+        .package((*note_package).clone())
+        .tag(NoteTag::with_account_target(counter_account.id()).into())
+        .build()
+        .expect("failed to build forged_note");
     let tx_script = build_send_notes_script(&counter_account, std::slice::from_ref(&forged_note));
 
     let tx_context_builder = chain

--- a/tests/integration-network/src/mockchain/counter_contract_rust_auth.rs
+++ b/tests/integration-network/src/mockchain/counter_contract_rust_auth.rs
@@ -4,13 +4,9 @@
 //! RPO-Falcon512 secret key cannot create notes on behalf of the counter
 //! contract account that uses the Rust-compiled auth component.
 
-use miden_client::{
-    auth::BasicAuthenticator,
-    crypto::RpoRandomCoin,
-    note::NoteTag,
-    testing::{MockChain, NoteBuilder},
-    transaction::{OutputNote, RawOutputNote},
-};
+use miden_client::{auth::BasicAuthenticator, note::NoteTag, transaction::RawOutputNote};
+use miden_protocol::crypto::rand::RandomCoin;
+use miden_standards::testing::note::NoteBuilder;
 use miden_testing::MockChain;
 use midenc_expect_test::expect;
 
@@ -19,10 +15,8 @@ use super::{
     helpers::{
         assert_counter_storage, block_on, build_counter_account_with_rust_rpo_auth,
         build_send_notes_script, compile_rust_package, counter_storage_slot_name,
-        create_note_from_package, NoteCreationConfig,
     },
 };
-use crate::mockchain::helpers::compile_rust_package;
 
 /// Verify that another client (without the RPO-Falcon512 key) cannot create notes for
 /// the counter account which uses the Rust-compiled RPO-Falcon512 authentication component.
@@ -60,7 +54,7 @@ pub fn test_counter_contract_rust_auth_blocks_unauthorized_note_creation() {
     );
 
     // Positive check: original client (with the key) can create a note
-    let rng = RpoRandomCoin::new(note_package.unwrap_program().hash());
+    let rng = RandomCoin::new(note_package.unwrap_program().hash());
     let own_note = NoteBuilder::new(counter_account.id(), rng)
         .package((*note_package).clone())
         .tag(NoteTag::with_account_target(counter_account.id()).into())
@@ -87,7 +81,7 @@ pub fn test_counter_contract_rust_auth_blocks_unauthorized_note_creation() {
 
     // Negative check: without the RPO-Falcon512 key, creating output notes should fail.
     let counter_account = chain.committed_account(counter_account_id).unwrap().clone();
-    let rng = RpoRandomCoin::new(note_package.unwrap_program().hash());
+    let rng = RandomCoin::new(note_package.unwrap_program().hash());
     let forged_note = NoteBuilder::new(counter_account.id(), rng)
         .package((*note_package).clone())
         .tag(NoteTag::with_account_target(counter_account.id()).into())

--- a/tests/integration-network/src/mockchain/helpers.rs
+++ b/tests/integration-network/src/mockchain/helpers.rs
@@ -60,8 +60,8 @@ pub(super) fn compile_rust_package(project_path: &str, release: bool) -> Arc<Pac
     let output = std::process::Command::new("miden")
                 .arg("build")
                 // Midenup's "miden build" command inherits all of cargo miden's flags.
-                .arg("--manifest-path")
-                .arg(std::path::Path::new(project_path).join("Cargo.toml"))
+                .current_dir(project_path)
+                .env("MIDENUP_MANIFEST_URI", format!("file://{project_path}/channel-manifest.json"))
                 .arg(mode_flag)
                 .output()
                 // TODO: Add the cargo install command once `midenup` is published

--- a/tests/integration-network/src/mockchain/helpers.rs
+++ b/tests/integration-network/src/mockchain/helpers.rs
@@ -16,7 +16,7 @@ use miden_client::{
     transaction::RawOutputNote,
     Deserializable, Word,
 };
-use miden_core::Felt;
+use miden_core::{crypto::hash::Rpo256, Felt, FieldElement};
 use miden_integration_tests::CompilerTestBuilder;
 use miden_mast_package::Package;
 use miden_protocol::{
@@ -56,36 +56,15 @@ pub(super) fn block_on<F: Future>(future: F) -> F::Output {
 // ================================================================================================
 
 pub(super) fn compile_rust_package(project_path: &str, release: bool) -> Arc<Package> {
-    let mode_flag = if release { "--release" } else { "--dev" };
-    let output = std::process::Command::new("miden")
-                .arg("build")
-                // Midenup's "miden build" command inherits all of cargo miden's flags.
-                .current_dir(project_path)
-                .env("MIDENUP_MANIFEST_URI", format!("file://{project_path}/channel-manifest.json"))
-                .arg(mode_flag)
-                .output()
-                // TODO: Add the cargo install command once `midenup` is published
-                // in crates.io.
-                .expect("failed to execute `miden build`. Is midenup installed?.
-    If not, follow the installation instructions in: https://github.com/0xMiden/midenup");
+    let config = WasmTranslationConfig::default();
+    let mut builder = CompilerTestBuilder::rust_source_cargo_miden(project_path, config, []);
 
-    if !output.status.success() {
-        panic!("miden build failed:\n{}", String::from_utf8_lossy(&output.stderr))
+    if release {
+        builder.with_release(true);
     }
 
-    // Read the .masp artifact from the project's target directory
-    let masp_path = std::path::Path::new(project_path)
-        .join("target/miden/release")
-        .read_dir()
-        .expect("failed to read target/miden/release")
-        .filter_map(|e| e.ok())
-        .find(|e| e.path().extension().is_some_and(|ext| ext == "masp"))
-        .map(|entry| entry.path())
-        .expect("no .masp file found in target/miden/release");
-
-    let masp_bytes = std::fs::read(&masp_path).expect("failed to read .masp artifact");
-
-    Arc::new(Package::read_from_bytes(&masp_bytes).expect("failed to parse .masp package"))
+    let mut test = builder.build();
+    test.compile_package()
 }
 
 // ================================================================================================

--- a/tests/integration-network/src/mockchain/helpers.rs
+++ b/tests/integration-network/src/mockchain/helpers.rs
@@ -3,36 +3,33 @@
 use std::{future::Future, sync::Arc};
 
 use miden_client::{
-    account::{
-        component::{BasicWallet, InitStorageData},
-        AccountStorage, StorageSlotName,
-    },
+    Word,
+    account::component::{BasicWallet, InitStorageData},
     asset::FungibleAsset,
     auth::AuthSecretKey,
     crypto::FeltRng,
-    note::{
-        Note, NoteAssets, NoteMetadata, NoteRecipient, NoteScript, NoteStorage, NoteTag, NoteType,
-    },
+    note::{Note, NoteType},
     transaction::RawOutputNote,
-    Deserializable, Word,
 };
-use miden_core::{crypto::hash::Rpo256, Felt, FieldElement};
+use miden_core::Felt;
 use miden_integration_tests::CompilerTestBuilder;
 use miden_mast_package::Package;
 use miden_protocol::{
     account::{
         Account, AccountBuilder, AccountComponent, AccountComponentMetadata, AccountId,
-        AccountStorage, AccountStorageMode, AccountType, StorageMap, StorageMapKey, StorageSlot,
-        StorageSlotNamefeat,
+        AccountStorage, AccountStorageMode, AccountType, StorageSlot, StorageSlotName,
     },
     asset::Asset,
     note::PartialNote,
     transaction::{TransactionMeasurements, TransactionScript},
 };
-use miden_standards::account::interface::{AccountInterface, AccountInterfaceExt};
+use miden_standards::{
+    account::interface::{AccountInterface, AccountInterfaceExt},
+    testing::note::NoteBuilder,
+};
 use miden_testing::{MockChain, TransactionContextBuilder};
 use midenc_frontend_wasm::WasmTranslationConfig;
-use rand::{rngs::StdRng, SeedableRng};
+use rand::{SeedableRng, rngs::StdRng};
 
 /// Converts a value's felt representation into `miden_core::Felt` elements.
 pub(super) fn to_core_felts(value: &AccountId) -> Vec<Felt> {
@@ -156,7 +153,7 @@ pub(super) fn build_asset_transfer_tx(
     let output_note = NoteBuilder::new(sender_id, rng)
         .serial_number(serial_num)
         .package((*p2id_note_package).clone())
-        .note_inputs(to_core_felts(&recipient_id))
+        .note_storage(to_core_felts(&recipient_id))
         .unwrap()
         .add_assets([asset])
         .tag(0)
@@ -174,7 +171,7 @@ pub(super) fn build_asset_transfer_tx(
     let recipient_digest: [Felt; 4] = output_note.recipient().digest().into();
     commitment_input.extend(recipient_digest);
 
-    let asset_elements = miden_protocol::asset::Asset::from(asset).as_elements();
+    let asset_elements = asset.as_elements();
     commitment_input.extend(asset_elements);
     // Ensure word alignment for `adv_load_preimage` in the tx script.
     commitment_input.extend([Felt::ZERO, Felt::ZERO]);
@@ -240,13 +237,14 @@ pub(super) fn build_existing_counter_account_builder_with_auth_package(
     auth_storage_slots: Vec<StorageSlot>,
     seed: [u8; 32],
 ) -> AccountBuilder {
-    let supported_types = BTreeSet::from_iter([AccountType::RegularAccountUpdatableCode]);
+    let metadata =
+        AccountComponentMetadata::new("auth", [AccountType::RegularAccountUpdatableCode]);
     let auth_component = AccountComponent::new(
         auth_component_package.unwrap_library().as_ref().clone(),
         auth_storage_slots,
+        metadata,
     )
-    .unwrap()
-    .with_supported_types(supported_types);
+    .unwrap();
 
     AccountBuilder::new(seed)
         .account_type(AccountType::RegularAccountUpdatableCode)

--- a/tests/integration-network/src/mockchain/helpers.rs
+++ b/tests/integration-network/src/mockchain/helpers.rs
@@ -3,8 +3,10 @@
 use std::{future::Future, sync::Arc};
 
 use miden_client::{
-    Word,
-    account::component::BasicWallet,
+    account::{
+        component::{BasicWallet, InitStorageData},
+        AccountStorage, StorageSlotName,
+    },
     asset::FungibleAsset,
     auth::AuthSecretKey,
     crypto::FeltRng,
@@ -12,6 +14,7 @@ use miden_client::{
         Note, NoteAssets, NoteMetadata, NoteRecipient, NoteScript, NoteStorage, NoteTag, NoteType,
     },
     transaction::RawOutputNote,
+    Deserializable, Word,
 };
 use miden_core::Felt;
 use miden_integration_tests::CompilerTestBuilder;
@@ -20,7 +23,7 @@ use miden_protocol::{
     account::{
         Account, AccountBuilder, AccountComponent, AccountComponentMetadata, AccountId,
         AccountStorage, AccountStorageMode, AccountType, StorageMap, StorageMapKey, StorageSlot,
-        StorageSlotName,
+        StorageSlotNamefeat,
     },
     asset::Asset,
     note::PartialNote,
@@ -29,7 +32,7 @@ use miden_protocol::{
 use miden_standards::account::interface::{AccountInterface, AccountInterfaceExt};
 use miden_testing::{MockChain, TransactionContextBuilder};
 use midenc_frontend_wasm::WasmTranslationConfig;
-use rand::{SeedableRng, rngs::StdRng};
+use rand::{rngs::StdRng, SeedableRng};
 
 /// Converts a value's felt representation into `miden_core::Felt` elements.
 pub(super) fn to_core_felts(value: &AccountId) -> Vec<Felt> {
@@ -52,104 +55,42 @@ pub(super) fn block_on<F: Future>(future: F) -> F::Output {
 // COMPILATION
 // ================================================================================================
 
-/// Helper to compile a Rust package to a Miden `Package`.
-pub(super) fn compile_rust_package(package_path: &str, release: bool) -> Arc<Package> {
-    let config = WasmTranslationConfig::default();
-    let mut builder = CompilerTestBuilder::rust_source_cargo_miden(package_path, config, []);
+pub(super) fn compile_rust_package(project_path: &str, release: bool) -> Arc<Package> {
+    let mode_flag = if release { "--release" } else { "--dev" };
+    let output = std::process::Command::new("miden")
+                .arg("build")
+                // Midenup's "miden build" command inherits all of cargo miden's flags.
+                .arg("--manifest-path")
+                .arg(std::path::Path::new(project_path).join("Cargo.toml"))
+                .arg(mode_flag)
+                .output()
+                // TODO: Add the cargo install command once `midenup` is published
+                // in crates.io.
+                .expect("failed to execute `miden build`. Is midenup installed?.
+    If not, follow the installation instructions in: https://github.com/0xMiden/midenup");
 
-    if release {
-        builder.with_release(true);
+    if !output.status.success() {
+        panic!("miden build failed:\n{}", String::from_utf8_lossy(&output.stderr))
     }
 
-    let mut test = builder.build();
-    test.compile_package()
+    // Read the .masp artifact from the project's target directory
+    let masp_path = std::path::Path::new(project_path)
+        .join("target/miden/release")
+        .read_dir()
+        .expect("failed to read target/miden/release")
+        .filter_map(|e| e.ok())
+        .find(|e| e.path().extension().is_some_and(|ext| ext == "masp"))
+        .map(|entry| entry.path())
+        .expect("no .masp file found in target/miden/release");
+
+    let masp_bytes = std::fs::read(&masp_path).expect("failed to read .masp artifact");
+
+    Arc::new(Package::read_from_bytes(&masp_bytes).expect("failed to parse .masp package"))
 }
 
-// NOTE HELPERS
 // ================================================================================================
-
-/// Configuration for creating a note.
-#[derive(Debug, Clone)]
-pub(super) struct NoteCreationConfig {
-    /// The note type (public/private).
-    pub note_type: NoteType,
-    /// The note tag.
-    pub tag: NoteTag,
-    /// Assets carried by the note.
-    pub assets: NoteAssets,
-    /// Note inputs (e.g. target account id, timelock/reclaim height, etc.).
-    pub inputs: Vec<Felt>,
-}
-
-impl Default for NoteCreationConfig {
-    fn default() -> Self {
-        Self {
-            note_type: NoteType::Public,
-            tag: NoteTag::new(0),
-            assets: Default::default(),
-            inputs: Default::default(),
-        }
-    }
-}
-
-/// Creates a note from a compiled note package without requiring a `miden_client::Client`.
-pub(super) fn create_note_from_package(
-    package: Arc<Package>,
-    sender_id: AccountId,
-    config: NoteCreationConfig,
-    rng: &mut impl FeltRng,
-) -> Note {
-    let note_program = package.unwrap_program();
-    let note_script =
-        NoteScript::from_parts(note_program.mast_forest().clone(), note_program.entrypoint());
-
-    let serial_num = rng.draw_word();
-    let note_storage = NoteStorage::new(config.inputs).unwrap();
-    let recipient = NoteRecipient::new(serial_num, note_script, note_storage);
-
-    let metadata = NoteMetadata::new(sender_id, config.note_type).with_tag(config.tag);
-
-    Note::new(config.assets, metadata, recipient)
-}
-
 // ACCOUNT COMPONENT HELPERS
 // ================================================================================================
-
-/// Creates an account component from a compiled package's component metadata.
-pub(super) fn account_component_from_package(
-    package: Arc<Package>,
-    storage_slots: Vec<StorageSlot>,
-) -> AccountComponent {
-    let metadata = AccountComponentMetadata::try_from(package.as_ref())
-        .expect("no account component metadata present");
-    AccountComponent::new(package.unwrap_library().as_ref().clone(), storage_slots, metadata)
-        .unwrap()
-}
-
-// BASIC WALLET HELPERS
-// ================================================================================================
-
-/// Builds an account builder for an existing basic-wallet account based on the provided component
-/// package.
-pub(super) fn build_existing_basic_wallet_account_builder(
-    wallet_package: Arc<Package>,
-    with_std_basic_wallet: bool,
-    seed: [u8; 32],
-) -> AccountBuilder {
-    let wallet_component = account_component_from_package(wallet_package, vec![]);
-
-    let mut builder = AccountBuilder::new(seed)
-        .account_type(AccountType::RegularAccountUpdatableCode)
-        .storage_mode(AccountStorageMode::Public);
-
-    if with_std_basic_wallet {
-        builder = builder.with_component(BasicWallet);
-    }
-
-    builder = builder.with_component(wallet_component);
-
-    builder
-}
 
 /// Asserts that the account vault contains a fungible asset from the expected faucet with the
 /// expected total amount.
@@ -224,10 +165,6 @@ pub(super) fn build_asset_transfer_tx(
     tx_script_package: Arc<Package>,
     rng: &mut impl FeltRng,
 ) -> (TransactionContextBuilder, Note) {
-    let note_program = p2id_note_package.unwrap_program();
-    let note_script =
-        NoteScript::from_parts(note_program.mast_forest().clone(), note_program.entrypoint());
-
     let tx_script_program = tx_script_package.unwrap_program();
     let tx_script = TransactionScript::from_parts(
         tx_script_program.mast_forest().clone(),
@@ -235,20 +172,27 @@ pub(super) fn build_asset_transfer_tx(
     );
 
     let serial_num = rng.draw_word();
-    let note_storage = NoteStorage::new(to_core_felts(&recipient_id)).unwrap();
-    let note_recipient = NoteRecipient::new(serial_num, note_script, note_storage);
 
-    let config = NoteCreationConfig {
-        assets: NoteAssets::new(vec![asset.into()]).unwrap(),
-        ..Default::default()
-    };
-    let metadata = NoteMetadata::new(sender_id, config.note_type).with_tag(config.tag);
-    let output_note = Note::new(config.assets, metadata, note_recipient.clone());
+    let asset: Asset = asset.into();
+    let output_note = NoteBuilder::new(sender_id, rng)
+        .serial_number(serial_num)
+        .package((*p2id_note_package).clone())
+        .note_inputs(to_core_felts(&recipient_id))
+        .unwrap()
+        .add_assets([asset])
+        .tag(0)
+        .build()
+        .unwrap();
 
     // Prepare commitment data
     // This must match the input layout expected by `examples/basic-wallet-tx-script`.
-    let mut commitment_input: Vec<Felt> = vec![config.tag.into(), Felt::from(config.note_type)];
-    let recipient_digest: [Felt; 4] = note_recipient.digest().into();
+    let mut commitment_input: Vec<Felt> = vec![
+        // The output's note tag
+        Felt::new(0u64),
+        // The output's note type
+        Felt::from(NoteType::Public),
+    ];
+    let recipient_digest: [Felt; 4] = output_note.recipient().digest().into();
     commitment_input.extend(recipient_digest);
 
     let asset_elements = miden_protocol::asset::Asset::from(asset).as_elements();
@@ -312,14 +256,18 @@ pub(super) fn assert_counter_storage(
 /// Builds an account builder for an existing public counter account containing the counter
 /// contract component and a custom authentication component compiled as a package library.
 pub(super) fn build_existing_counter_account_builder_with_auth_package(
-    contract_package: Arc<Package>,
+    counter_component: AccountComponent,
     auth_component_package: Arc<Package>,
     auth_storage_slots: Vec<StorageSlot>,
-    counter_storage_slots: Vec<StorageSlot>,
     seed: [u8; 32],
 ) -> AccountBuilder {
-    let auth_component = account_component_from_package(auth_component_package, auth_storage_slots);
-    let counter_component = account_component_from_package(contract_package, counter_storage_slots);
+    let supported_types = BTreeSet::from_iter([AccountType::RegularAccountUpdatableCode]);
+    let auth_component = AccountComponent::new(
+        auth_component_package.unwrap_library().as_ref().clone(),
+        auth_storage_slots,
+    )
+    .unwrap()
+    .with_supported_types(supported_types);
 
     AccountBuilder::new(seed)
         .account_type(AccountType::RegularAccountUpdatableCode)
@@ -340,10 +288,13 @@ pub(super) fn build_counter_account_with_rust_rpo_auth(
 ) -> (Account, AuthSecretKey) {
     let key = Word::from([Felt::ZERO, Felt::ZERO, Felt::ZERO, Felt::ONE]);
     let value = Word::from([Felt::ZERO, Felt::ZERO, Felt::ZERO, Felt::ONE]);
-    let counter_storage_slots = vec![StorageSlot::with_map(
-        counter_storage_slot_name(),
-        StorageMap::with_entries([(StorageMapKey::new(key), value)]).unwrap(),
-    )];
+    let mut counter_init_storage_data = InitStorageData::default();
+    counter_init_storage_data
+        .insert_map_entry(counter_storage_slot_name(), key, value)
+        .expect("failed to insert counter map entry");
+
+    let counter_component =
+        AccountComponent::from_package(&component_package, &counter_init_storage_data).unwrap();
 
     let mut rng = StdRng::seed_from_u64(1);
     let secret_key = AuthSecretKey::new_falcon512_poseidon2_with_rng(&mut rng);
@@ -353,10 +304,9 @@ pub(super) fn build_counter_account_with_rust_rpo_auth(
         vec![StorageSlot::with_value(auth_public_key_slot_name(), pk_commitment)];
 
     let account = build_existing_counter_account_builder_with_auth_package(
-        component_package,
+        counter_component,
         auth_component_package,
         auth_storage_slots,
-        counter_storage_slots,
         seed,
     )
     .build_existing()


### PR DESCRIPTION
This PR aims to re work the testing harness merged [here]() in order for it to work for integration tests.

A thing that was common in all the `integration-network` tests was the presence of "repetitive" boilerplate code to set up a couple of basic wallet accounts inside a `MockChain`. See:
- [test_basic_wallet_p2id](https://github.com/0xMiden/compiler/blob/3da498295bfa8094d0bcd4bab5db8c7ee123c2c0/tests/integration-network/src/mockchain/basic_wallet.rs#L20-L51)
- [test_basic_wallet_p2ide](https://github.com/0xMiden/compiler/blob/3da498295bfa8094d0bcd4bab5db8c7ee123c2c0/tests/integration-network/src/mockchain/basic_wallet.rs#L125C8-L156)
- [test_basic_wallet_p2ide_reclaim](https://github.com/0xMiden/compiler/blob/next/tests/integration-network/src/mockchain/basic_wallet.rs#L125C8-L156)

With this in mind, this PR aims to aid in reducing the amount of boilerplate required to set up the context for a test. To achieve this, I went with a `clap`-esque/[operation](https://github.com/0xMiden/compiler/blob/next/hir-macros/src/lib.rs#L64)-esque approach.

Currently, it looks like so:
```rust
#[miden_test(
    chain(name = "builder"),
    faucet(name = "faucet", max_supply = 1_000_000_000)
)]
pub fn test_basic_wallet_p2id() {
    (...)
}
```

Which replaced the following lines:
```rust
#[test]
pub fn test_basic_wallet_p2id() {
    (...)
    let mut builder = MockChain::builder();
    let max_supply = 1_000_000_000u64;
    let faucet_account = builder
        .add_existing_basic_faucet(Auth::BasicAuth, "TEST", max_supply, None)
        .unwrap();
    (...)        
}
```

The plan is to have something along these lines:

```rust
#[miden_test(
    chain(name = "builder"),
    faucet(name = "faucet", max_supply = 1_000_000_000),
    account(name = "bob"),
    account(name = "alice"),
)]
pub fn test_basic_wallet_p2id() {
    (...)
}
```

To replace the following:
```rust
#[test]
pub fn test_basic_wallet_p2id() {
    let mut builder = MockChain::builder();
    let max_supply = 1_000_000_000u64;
    let faucet_account = builder
        .add_existing_basic_faucet(Auth::BasicAuth, "TEST", max_supply, None)
        .unwrap();

    let alice_account = builder
        .add_account_from_builder(
            Auth::BasicAuth,
            build_existing_basic_wallet_account_builder(wallet_package.clone(), false, [1_u8; 32]),
            AccountState::Exists,
        )
        .unwrap();

    let bob_account = builder
        .add_account_from_builder(
            Auth::BasicAuth,
            build_existing_basic_wallet_account_builder(wallet_package, false, [2_u8; 32]),
            AccountState::Exists,
        )
        .unwrap();
}
```

This probably supersede the previous syntax where the "special"/"magic" recognized keywords 